### PR TITLE
Fix deploy.py for CI and add PolyForm Noncommercial license

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,14 @@ python3 generate.py --output-dir ../dist --api-endpoint <API_ENDPOINT>
 Run from the `cloudformation/` directory:
 
 ```bash
+# Local deployment with AWS profile
 python3 ./deploy.py --account <AWS_PROFILE> --region us-east-1 --domain <DOMAIN> --prefix <PREFIX>
 
+# CI/CD deployment (uses OIDC credentials from environment)
+python3 ./deploy.py --region us-east-1 --domain <DOMAIN> --prefix <PREFIX>
+
 # Optional parameters:
+#   --account <AWS_PROFILE>            AWS named profile (optional in CI)
 #   --bucketlogslifecycle <days>       Log retention (default: 365)
 #   --buckettransitionlifecycle <days> Storage transition (default: 30)
 #   --validate                         Validate template only

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,136 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software
+to do everything you might do with the software that would
+otherwise infringe the licensor's copyright in it for any
+permitted purpose.  However, you may only distribute the
+software according to [Distribution License](#distribution-license) and make
+changes or new works based on the software according to
+[Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Crofton Cloud (https://crofton.cloud)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization, or
+government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law.  These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately.  If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.
+
+---
+
+Required Notice: Copyright (c) 2026 Crofton Cloud (https://crofton.cloud)
+
+For licensing inquiries, contact: licensing@crofton.cloud

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ python3 generate.py --output-dir ../dist
 
 ```bash
 cd cloudformation
+# Local deployment with AWS profile
 python3 deploy.py --account <AWS_PROFILE> --domain <DOMAIN> --prefix <PREFIX>
+
+# CI/CD deployment (uses OIDC credentials from environment)
+python3 deploy.py --domain <DOMAIN> --prefix <PREFIX>
 ```
 
 ## Repository Structure
@@ -127,4 +131,4 @@ python3 deploy.py --account <AWS_PROFILE> --domain <DOMAIN> --prefix <PREFIX>
 
 ## License
 
-MIT
+[PolyForm Noncommercial 1.0.0](LICENSE) - Free for non-commercial use.


### PR DESCRIPTION
## Summary

- Fix deploy.py to work in CI/CD environments where AWS credentials are provided via OIDC
- Add PolyForm Noncommercial 1.0.0 license to match other portfolio repositories

## Changes

- `cloudformation/deploy.py` - Make `--account` parameter optional
- `LICENSE` - Add PolyForm Noncommercial 1.0.0 license
- `README.md` - Update deploy command examples and license reference
- `CLAUDE.md` - Update deploy command documentation

## Root Cause

The deploy workflow was failing because `deploy.py` required `--account` (AWS profile name), but in CI the credentials are provided via environment variables from OIDC authentication.

## Test plan

- [ ] Verify deploy workflow passes on develop
- [ ] Merge to main and verify full deployment succeeds