### PR TITLE
Fix logs:DescribeLogGroups permission for CloudFormation

### DIFF
--- a/cloudformation/github-oidc-deploy-role.yaml
+++ b/cloudformation/github-oidc-deploy-role.yaml
@@ -427,6 +427,15 @@ Resources:
   # Policy for CloudWatch Logs (Lambda and API Gateway logging)
   CloudWatchLogsPolicy:
     Type: AWS::IAM::Policy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: logs:DescribeLogGroups is an account-level action requiring Resource '*'
+      checkov:
+        skip:
+          - id: CKV_AWS_111
+            comment: logs:DescribeLogGroups requires Resource '*'. OIDC trust restricts to this repository only.
     Properties:
       PolicyName: CloudWatchLogsManagement
       Roles:
@@ -443,11 +452,15 @@ Resources:
               - logs:DeleteRetentionPolicy
               - logs:TagLogGroup
               - logs:UntagLogGroup
-              - logs:DescribeLogGroups
               - logs:ListTagsLogGroup
             Resource:
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${ProjectPrefix}-*'
               - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/apigateway/${ProjectPrefix}-*'
+          - Sid: CloudWatchLogsDescribe
+            Effect: Allow
+            Action:
+              - logs:DescribeLogGroups
+            Resource: '*'
 
   # Policy for SQS (event notifications)
   SQSPolicy:


### PR DESCRIPTION
## Summary
- Separated `logs:DescribeLogGroups` into its own statement with `Resource: '*'`
- This is an account-level action that cannot be scoped to specific log group ARNs
- Similar to the `cloudformation:ValidateTemplate` fix from PR #24

## Root Cause
The contact form stack creation failed because CloudFormation couldn't resolve the ARN attribute for log groups - the `logs:DescribeLogGroups` permission was scoped to specific log group ARNs but the action requires account-level access.

## Test plan
- [x] OIDC role stack updated manually in AWS
- [x] Failed `cc-contact-form` stack deleted
- [ ] Merge PR and verify deployment creates contact form stack successfully