### PR TITLE
Add CloudWatch Logs delivery permissions for API Gateway access logging

### DIFF
--- a/cloudformation/github-oidc-deploy-role.yaml
+++ b/cloudformation/github-oidc-deploy-role.yaml
@@ -452,11 +452,11 @@ Resources:
       cfn_nag:
         rules_to_suppress:
           - id: W12
-            reason: logs:DescribeLogGroups is an account-level action requiring Resource '*'
+            reason: Log delivery and describe actions are account-level requiring Resource '*'
       checkov:
         skip:
           - id: CKV_AWS_111
-            comment: logs:DescribeLogGroups requires Resource '*'. OIDC trust restricts to this repository only.
+            comment: Log delivery and describe actions require Resource '*'. OIDC trust restricts to this repository only.
     Properties:
       PolicyName: CloudWatchLogsManagement
       Roles:
@@ -486,6 +486,19 @@ Resources:
             Effect: Allow
             Action:
               - logs:DescribeLogGroups
+              - logs:DescribeResourcePolicies
+              - logs:PutResourcePolicy
+              - logs:DeleteResourcePolicy
+            Resource: '*'
+          # API Gateway V2 access logging requires log delivery permissions
+          - Sid: CloudWatchLogsDelivery
+            Effect: Allow
+            Action:
+              - logs:CreateLogDelivery
+              - logs:GetLogDelivery
+              - logs:UpdateLogDelivery
+              - logs:DeleteLogDelivery
+              - logs:ListLogDeliveries
             Resource: '*'
 
   # Policy for SQS (event notifications)


### PR DESCRIPTION
## Summary

Adds CloudWatch Logs delivery permissions required for API Gateway V2 access logging.

### Error Fixed

```
User is not authorized to perform: logs:CreateLogDelivery because no identity-based policy allows the logs:CreateLogDelivery action
```

### Permissions Added

| Permission | Purpose |
|------------|---------|
| `logs:CreateLogDelivery` | Create log delivery for API Gateway access logs |
| `logs:GetLogDelivery` | Read log delivery configuration |
| `logs:UpdateLogDelivery` | Update log delivery settings |
| `logs:DeleteLogDelivery` | Remove log delivery on stack deletion |
| `logs:ListLogDeliveries` | List existing log deliveries |
| `logs:DescribeResourcePolicies` | Read log resource policies |
| `logs:PutResourcePolicy` | Create/update log resource policies |
| `logs:DeleteResourcePolicy` | Remove log resource policies |

These are account-level actions (`Resource: '*'`) required by API Gateway V2 to write access logs to CloudWatch Logs.

### Verification

- [x] Pre-commit checks pass
- [x] OIDC role stack updated in AWS
- [x] Failed `cc-contact-form` stack deleted

## Test plan

- [ ] Merge PR and verify contact form stack creates successfully
- [ ] Verify API Gateway stage has access logging enabled