### PR TITLE
Add KMS grant permissions for Lambda encrypted environment variables

### DIFF
--- a/cloudformation/github-oidc-deploy-role.yaml
+++ b/cloudformation/github-oidc-deploy-role.yaml
@@ -306,6 +306,10 @@ Resources:
               - kms:Encrypt
               - kms:Decrypt
               - kms:GenerateDataKey
+              # Required for Lambda KMS-encrypted environment variables
+              - kms:CreateGrant
+              - kms:RetireGrant
+              - kms:ListGrants
               # Required for stack deletion
               - kms:ScheduleKeyDeletion
             Resource: '*'


### PR DESCRIPTION
## Summary

Adds KMS grant permissions required for Lambda functions using customer-managed KMS keys to encrypt environment variables.

### Error Fixed

```
Lambda was unable to configure access to your environment variables because KMS returned Access Denied.
User is not authorized to perform: kms:CreateGrant
```

### Permissions Added

| Permission | Purpose |
|------------|---------|
| `kms:CreateGrant` | Allow Lambda to create grants for environment variable encryption |
| `kms:RetireGrant` | Allow grants to be retired on function deletion |
| `kms:ListGrants` | List existing grants on KMS keys |

### Verification

- [x] Pre-commit checks pass
- [x] OIDC role stack updated in AWS
- [x] Failed `cc-contact-form` stack deleted

## Test plan

- [ ] Merge PR and verify contact form stack creates successfully
- [ ] Verify Lambda function is created with KMS-encrypted environment variables